### PR TITLE
Update iam.tf

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role" "local_role" {
       {
         Action = "sts:AssumeRole"
         Effect = "Allow"
-        Sid    = ""
+        Sid    = "iamrolepolicy"
         Principal = {
           AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
         }


### PR DESCRIPTION
Deployment of this terraform stack in my local AWS environment failed and claimed malformed json. An IAM role requires a non-empty Sid. If a more descriptive name is better, feel free to use something else :)

#### What this PR does / why we need it:
This PR addresses an incorrect IAM policy in iam.tf. A policy requires a non-empty Sid. Once added, terraform successfully spins up the EKS environment.
#### Which issue(s) this PR fixes:
493: Malformed json in iam.tf
Fixes #

#### Quality checks

- [ x] My content adheres to the style guidelines
- [x ] I ran `make test` or `make e2e-test` and it was successful - I ran terraform fmt and deployed to local environment with the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
